### PR TITLE
Update README form example to use TomSelectConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,16 @@ urlpatterns = [
 
 5. **Use in your forms:**
 ```python
-from django_tomselect.forms import TomSelectModelChoiceField
+from django_tomselect.forms import TomSelectModelChoiceField, TomSelectConfig
 
 class MyForm(forms.Form):
     person = TomSelectModelChoiceField(
-        url="person_autocomplete",
-        value_field="id",
-        label_field="full_name",
+        queryset=Person.objects.all(),
+        TomSelectConfig(
+            url="person_autocomplete",
+            value_field="id",
+            label_field="full_name",
+        )
     )
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ from django_tomselect.forms import TomSelectModelChoiceField, TomSelectConfig
 
 class MyForm(forms.Form):
     person = TomSelectModelChoiceField(
-        queryset=Person.objects.all(),
         TomSelectConfig(
             url="person_autocomplete",
             value_field="id",


### PR DESCRIPTION
## Rationale
I was trying to follow the example from the README using this form:

```py
from django_tomselect.forms import TomSelectModelChoiceField

class MyForm(forms.Form):
    person = TomSelectModelChoiceField(
        url="person_autocomplete",
        value_field="id",
        label_field="full_name",
    )
```

but was getting an error: 

```sh
django.urls.exceptions.NoReverseMatch: Reverse for 'autocomplete' not found. 'autocomplete' is not a valid view function or pattern name.
```

After some further digging in the docs realized there is the missing TomSelectConfig:

```py
from django_tomselect.forms import TomSelectModelChoiceField, TomSelectConfig

class MyForm(forms.Form):
    person = TomSelectModelChoiceField(
        queryset=Person.objects.all(),
        TomSelectConfig(
            url="person_autocomplete",
            value_field="id",
            label_field="full_name",
        )
    )
```

Which resolves the issue!
