### PR TITLE
fix: Fix clear_button.html render template & documentation

### DIFF
--- a/docs/api/templates.md
+++ b/docs/api/templates.md
@@ -291,6 +291,30 @@ item: function(data, escape) {
 },
 ```
 
+### clear_button.html
+
+Renders the HTML for the clear button added by the `clear_button` plugin. Override this template to customise the button's markup, attributes, or icon.
+
+Template source: [clear_button.html](https://github.com/OmenApps/django-tomselect/blob/71547a01daea6992f5ed18b48d911d01a2d2ab4f/src/django_tomselect/templates/django_tomselect/render/clear_button.html)
+
+```django
+{% comment %}
+Renders the Clear Button plugin's HTML.
+{% endcomment %}
+{% load i18n %}
+{% block code %}
+html: function(data){
+    return `<div class="${escape(data.className)}"
+                title="${escape(data.title)}"
+                role="button"
+                aria-label="${escape(data.title)}"
+                tabindex="0">&times;</div>`;
+},
+title: "{% translate "Clear Selection" %}",
+className: "clear-button",
+{% endblock code %}
+```
+
 ### dropdown_header.html
 
 Configures the dropdown header display.

--- a/src/django_tomselect/templates/django_tomselect/render/clear_button.html
+++ b/src/django_tomselect/templates/django_tomselect/render/clear_button.html
@@ -7,7 +7,7 @@ html: function(data){
     return `<div class="${escape(data.className)}"
                 title="${escape(data.title)}"
                 role="button"
-                aria-label="{% translate 'Clear selection' %}"
+                aria-label="${escape(data.title)}"
                 tabindex="0">&times;</div>`;
 },
 {% endblock code %}

--- a/src/django_tomselect/templates/django_tomselect/tomselect.html
+++ b/src/django_tomselect/templates/django_tomselect/tomselect.html
@@ -246,7 +246,8 @@ You can also extend and call `{{ block.super }}` to augment existing logic.
                             {% if 'clear_button' in widget.plugins.keys %}
                                 clear_button: {
                                     title: '{{ widget.plugins.clear_button.title|escapejs }}',
-                                    className: '{{ widget.plugins.clear_button.class_name|escapejs }}'
+                                    className: '{{ widget.plugins.clear_button.class_name|escapejs }}',
+                                    {% include "django_tomselect/render/clear_button.html" with widget=widget %}
                                 },
                             {% endif %}
 


### PR DESCRIPTION
The `clear_button` plugin's render template (`render/clear_button.html`) exists and provides a custom `html` function, but `tomselect.html` never includes it — unlike `dropdown_header` and `dropdown_footer` which correctly use `{% include %}` for their render templates.

This means the documented template override mechanism for `clear_button` is silently broken: overriding the template has no effect on the rendered output.

This would let us overwrite nicely. Also added some documentation about it.
Feel free to edit this PR as you please!